### PR TITLE
add OrderedDict to avoid NameError

### DIFF
--- a/longformer_experiments/train_model.py
+++ b/longformer_experiments/train_model.py
@@ -1,4 +1,4 @@
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, OrderedDict
 import torch.nn.functional as F
 from typing import List,Any
 from transformers import LongformerTokenizerFast


### PR DESCRIPTION
Avoids the following error after the 2nd epoch, generated on line 134

<img width="597" alt="image" src="https://github.com/NorskRegnesentral/text-anonymization-benchmark/assets/2048170/86156ba5-cbab-44dc-a0cb-60e172ee9a20">
